### PR TITLE
Fix app crashing when the Google Sheet is bad (e.g. REF error)

### DIFF
--- a/GlobalTalk Updater/GTUpdater.swift
+++ b/GlobalTalk Updater/GTUpdater.swift
@@ -57,6 +57,13 @@ import AsyncDNSResolver
             Task {
                 var ipList: [String] = []
                 for row in rows {
+                    guard !row.isEmpty else {
+                        // If the row is empty there is a problem with the sheet
+                        self.lastError = "Unable to read the Google Sheet."
+                        self.state = .failed
+                        return
+                    }
+                    
                     var ip = row[0]
                     if self.invalidChars.contains(where: ip.contains) {
                         // Filter out rows with invalid characters


### PR DESCRIPTION
It was crashing for me, so I investigated it, and the Google Sheet had gone bad (someone had tried editing the list of IPs directly, causing the JustTheFacts page to just turn into one big #REF error). 

This pull request adds a sanity check to avoid an index-out-of-bounds error when a row in the sheet is blank.