### PR TITLE
Trim whitespace before checking for invalid chars

### DIFF
--- a/GlobalTalk Updater/GTUpdater.swift
+++ b/GlobalTalk Updater/GTUpdater.swift
@@ -59,7 +59,7 @@ import AsyncDNSResolver
                         continue
                     }
                     
-                    var ip = row[0]
+                    var ip = row[0].trimmingCharacters(in: .whitespacesAndNewlines)
                     if self.invalidChars.contains(where: ip.contains) {
                         // Filter out rows with invalid characters
                         continue


### PR DESCRIPTION
Fixes skipping otherwise valid rows that begin or end with whitespace.